### PR TITLE
Add version for Magento marketplace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,7 @@
     "description": "Extends Magento 2 transaction mails with a Schema.org conform HTML content",
     "type": "magento2-module",
     "license": "MIT",
+    "version": "1.0.1",
     "authors": [
         {
             "name": "Michael Vogel",


### PR DESCRIPTION
The version seems to be a mandatory Composer field for Magento marketplace. /cc @paecman 